### PR TITLE
Support for external DockerHub Images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,43 @@
+name: docker-ci
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths-ignore:
+      - '**/README.md'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      -
+        name: Build and push signaling-server
+        uses: docker/build-push-action@v2
+        with:
+          context: signaling-server/.
+          file: Dockerfile
+          push: true
+          tags: l4rm4nd/transferzip:signaling-server
+          platforms: linux/amd64
+      -
+        name: Build and push web-server
+        uses: docker/build-push-action@v2
+        with:
+          context: web-server/.
+          file: Dockerfile
+          push: true
+          tags: l4rm4nd/xingdumper:web-server
+          platforms: linux/amd64          

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,8 +27,8 @@ jobs:
         name: Build and push signaling-server
         uses: docker/build-push-action@v2
         with:
-          context: signaling-server/
-          file: Dockerfile
+          context: .
+          file: signaling-server/Dockerfile
           push: true
           tags: l4rm4nd/transferzip:signaling-server
           platforms: linux/amd64
@@ -36,8 +36,8 @@ jobs:
         name: Build and push web-server
         uses: docker/build-push-action@v2
         with:
-          context: web-server/
-          file: Dockerfile
+          context: .
+          file: web-server/Dockerfile
           push: true
-          tags: l4rm4nd/xingdumper:web-server
+          tags: l4rm4nd/transferzip:web-server
           platforms: linux/amd64          

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
         name: Build and push signaling-server
         uses: docker/build-push-action@v2
         with:
-          context: .
+          context: signaling-server/.
           file: signaling-server/Dockerfile
           push: true
           tags: l4rm4nd/transferzip:signaling-server
@@ -36,7 +36,7 @@ jobs:
         name: Build and push web-server
         uses: docker/build-push-action@v2
         with:
-          context: .
+          context: web-server/.
           file: web-server/Dockerfile
           push: true
           tags: l4rm4nd/transferzip:web-server

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
         name: Build and push signaling-server
         uses: docker/build-push-action@v2
         with:
-          context: signaling-server/.
+          context: signaling-server/
           file: Dockerfile
           push: true
           tags: l4rm4nd/transferzip:signaling-server
@@ -36,7 +36,7 @@ jobs:
         name: Build and push web-server
         uses: docker/build-push-action@v2
         with:
-          context: web-server/.
+          context: web-server/
           file: Dockerfile
           push: true
           tags: l4rm4nd/xingdumper:web-server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     #  - proxy
     #labels:
     #  - traefik.enable=true
-    #  - traefik.http.routers.transferzip.rule=Host(`tranfer.example.com`)
+    #  - traefik.http.routers.transferzip.rule=Host(`transfer.example.com`)
     #  - traefik.http.services.transferzip.loadbalancer.server.port=80
     #  - traefik.http.middlewares.limit.buffering.maxRequestBodyBytes=50000000 # optional, only necessary for enabled file uploads
     #  - traefik.http.middlewares.limit.buffering.maxResponseBodyBytes=50000000 # optional, only necessary for enabled file uploads

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,41 @@
+version: '3.3'
+
 services:
   web-server:
-    build: web-server
+    #build: web-server
+    image: l4rm4nd/transferzip:web-server
+    hostname: web-server
+    container_name: transferzip-web
+    restart: unless-stopped
+    expose:
+      - 80
+    depends_on:
+      - signaling-server
     ports:
       - 127.0.0.1:9001:80
+    #networks:
+    #  - proxy
+    #labels:
+    #  - traefik.enable=true
+    #  - traefik.http.routers.transferzip.rule=Host(`tranfer.example.com`)
+    #  - traefik.http.services.transferzip.loadbalancer.server.port=80
+    #  - traefik.http.middlewares.limit.buffering.maxRequestBodyBytes=50000000 # optional, only necessary for enabled file uploads
+    #  - traefik.http.middlewares.limit.buffering.maxResponseBodyBytes=50000000 # optional, only necessary for enabled file uploads
+    #  - traefik.http.middlewares.limit.buffering.memRequestBodyBytes=50000000 # optional, only necessary for enabled file uploads
+    #  - traefik.http.middlewares.limit.buffering.memResponseBodyBytes=50000000 # optional, only necessary for enabled file uploads    
+    #  - traefik.docker.network=proxy
+    #  # Part for optional traefik middlewares
+    #  - traefik.http.routers.transferzip.middlewares=local-ipwhitelist@file,authelia@file,basic-auth@file      
 
   signaling-server:
-    build: signaling-server
+    #build: signaling-server
+    image: l4rm4nd/transferzip:signaling-server
+    hostname: signaling-server
+    container_name: transferzip-signaling
+    restart: unless-stopped
+    #networks:
+    #  - proxy
+
+#networks:
+#  proxy:
+#    external: true    


### PR DESCRIPTION
Hey @robinkarlberg,

I've [forked your repository](https://github.com/l4rm4nd/transfer.zip-web) and implemented GitHub Actions quickly.

Afterwards, I also adjusted the provided `docker-compose.yml` to reflect the new information.

In order to merge, you have to:

- Create your GitHub repository secrets `DOCKER_HUB_ACCESS_TOKEN` and `DOCKER_HUB_USERNAME`. Basically your API token from Dockerhub and your username. You can create those on GitHub at https://github.com/robinkarlberg/transfer.zip-web/settings/secrets/actions
- Adjust the `.github/workflows/docker-image.yml` file (only the build tags) to hold your Dockerhub username + image + tags you want to use
- Adjust the `docker-compose.yml` file to reflect your Dockerhub image details

Cheers!
