### PR TITLE
Add slide-in animation for TransferSidebar

### DIFF
--- a/next/src/app/(app)/app/(index)/(list)/AnimatePresenceWrapper.js
+++ b/next/src/app/(app)/app/(index)/(list)/AnimatePresenceWrapper.js
@@ -1,0 +1,7 @@
+"use client"
+
+import { AnimatePresence } from "framer-motion"
+
+export default function AnimatePresenceWrapper({ children }) {
+  return <AnimatePresence mode="wait">{children}</AnimatePresence>
+}

--- a/next/src/app/(app)/app/(index)/(list)/[transferId]/TransferSidebar.js
+++ b/next/src/app/(app)/app/(index)/(list)/[transferId]/TransferSidebar.js
@@ -8,7 +8,7 @@ import { deleteTransfer, getTransferDownloadLink, putTransfer } from "@/lib/clie
 import { EXPIRATION_TIMES } from "@/lib/constants"
 import { humanFileSize } from "@/lib/transferUtils"
 import { parseTransferExpiryDate, tryCopyToClipboard } from "@/lib/utils"
-import { Transition } from "@headlessui/react"
+import { motion } from "framer-motion"
 import { useRouter } from "next/navigation"
 import { useContext, useMemo, useRef, useState } from "react"
 
@@ -172,9 +172,15 @@ export default function ({ user, transfer }) {
   }
 
   return (
-    <Transition show={!!selectedTransfer}>
-      <div className="z-20 --overflow-hidden duration-0 data-[closed]:w-0 data-[leave]:overflow-hidden data-[enter]:overflow-hidden fixed top-0 w-[100vw] h-full md:right-0 md:duration-300 md:w-96 xl:w-[512px]">
-        <div className="absolute h-full w-full md:w-96 xl:w-[512px]">
+    selectedTransfer && (
+      <motion.div
+          initial={{ x: "100%" }}
+          animate={{ x: 0 }}
+          exit={{ x: "100%" }}
+          transition={{ type: "tween", duration: 0.3 }}
+          className="z-20 fixed top-0 w-[100vw] h-full md:right-0 md:w-96 xl:w-[512px]"
+        >
+          <div className="absolute h-full w-full md:w-96 xl:w-[512px]">
           <Modal title={`Shared with ${selectedTransfer.emailsSharedWith.length} people`} icon={"envelope"} buttons={[
             { title: "Ok", onClick: () => setShowEmailList(false) }
           ]} show={showEmailList} onClose={() => setShowEmailList(false)}>
@@ -337,6 +343,7 @@ export default function ({ user, transfer }) {
           </div>
         </div>
       </div>
-    </Transition>
+        </motion.div>
+    )
   )
 }

--- a/next/src/app/(app)/app/(index)/(list)/[transferId]/page.js
+++ b/next/src/app/(app)/app/(index)/(list)/[transferId]/page.js
@@ -14,7 +14,10 @@ export default async function ({ params }) {
   }
 
   return (
-    // <div></div>
-    <TransferSidebar user={auth.user.friendlyObj()} transfer={transfer.friendlyObj()} />
+    <TransferSidebar
+      key={transferId}
+      user={auth.user.friendlyObj()}
+      transfer={transfer.friendlyObj()}
+    />
   )
 }

--- a/next/src/app/(app)/app/(index)/(list)/layout.js
+++ b/next/src/app/(app)/app/(index)/(list)/layout.js
@@ -3,6 +3,7 @@ import BIcon from "@/components/BIcon"
 import GenericPage from "@/components/dashboard/GenericPage"
 import Link from "next/link"
 import TransfersPage from "./TransfersPage"
+import AnimatePresenceWrapper from "./AnimatePresenceWrapper"
 import Transfer from "@/lib/server/mongoose/models/Transfer"
 import { useServerAuth } from "@/lib/server/wrappers/auth"
 import TransferRequest from "@/lib/server/mongoose/models/TransferRequest"
@@ -36,7 +37,9 @@ export default async function ({ children }) {
           transfers={transfers.map(transfer => transfer.friendlyObj())}
           transferRequests={transferRequestsWithCount}
         />
-        {children}
+        <AnimatePresenceWrapper>
+          {children}
+        </AnimatePresenceWrapper>
       </GenericPage>
     </DefaultLayout>
   )


### PR DESCRIPTION
## Summary
- add `AnimatePresenceWrapper` component
- apply `AnimatePresence` wrapper in transfer list layout
- move presence handling from `TransferSidebar` to layout
- key sidebar by transfer id in the page component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686844fb97508322afe8cfe5cfb6c557