### PR TITLE
Migrate tools and add metadata editor

### DIFF
--- a/frontend/src/routes/QuickSharePage.js
+++ b/frontend/src/routes/QuickSharePage.js
@@ -16,8 +16,8 @@ export default function QuickSharePage({ }) {
   const hasBeenSentLink = !!(k && remoteSessionId && transferDirection)
 
   return (
-    <div>
-      <main className="grid min-h-[100vh] place-items-center px-6 py-24 sm:py-32 lg:px-8 relative">
+    <div key={"prevent-scroll-bug-asdasd"}>
+      <div className="grid min-h-[100vh] place-items-center px-6 py-24 sm:py-32 lg:px-8 relative">
         <svg
           aria-hidden="true"
           className="absolute inset-0 -z-10 h-full w-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]"
@@ -51,7 +51,7 @@ export default function QuickSharePage({ }) {
             <Outlet />
           </QuickShareContext.Provider>
         </div>
-      </main>
+      </div>
       {/* <div>
         <h2></h2>
       </div> */}

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -25,7 +25,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.15.0",
-        "heic-convert": "^2.1.0",
+        "heic2any": "^0.0.4",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.514.0",
         "moment-timezone": "^0.5.48",
@@ -47,6 +47,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.16",
+        "@types/heic-convert": "^2.1.0",
         "@types/react": "^19.1.0",
         "dotenv-cli": "^8.0.0",
         "tailwindcss": "^4",
@@ -2346,6 +2347,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/heic-convert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/heic-convert/-/heic-convert-2.1.0.tgz",
+      "integrity": "sha512-Cf5Sdc2Gm2pfZ0uN1zjj35wcf3mF1lJCMIzws5OdJynrdMJRTIRUGa5LegbVg0hatzOPkH2uAf2JRjPYgl9apg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -3146,31 +3154,11 @@
       "integrity": "sha512-My8IVgPaNw1TPrcOtLxG5N2BQJUr2YYI8a3ei3Njx4QIZ+WzEkvLQ4jySrcy6YNfq1JwHpyimb4p2Rw5IuE/SA==",
       "license": "MIT"
     },
-    "node_modules/heic-convert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
-      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
-      "license": "ISC",
-      "dependencies": {
-        "heic-decode": "^2.0.0",
-        "jpeg-js": "^0.4.4",
-        "pngjs": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/heic-decode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.0.0.tgz",
-      "integrity": "sha512-NU+zsiDvdL+EebyTjrEqjkO2XYI7FgLhQzsbmO8dnnYce3S0PBSDm/ZyI4KpcGPXYEdb5W72vp/AQFuc4F8ASg==",
-      "license": "ISC",
-      "dependencies": {
-        "libheif-js": "^1.17.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/html-to-text": {
       "version": "9.0.5",
@@ -3251,12 +3239,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-base64": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
@@ -3328,15 +3310,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://ko-fi.com/killymxi"
-      }
-    },
-    "node_modules/libheif-js": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
-      "integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
-      "license": "LGPL-3.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/lightningcss": {
@@ -4566,15 +4539,6 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
-    },
-    "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
-      }
     },
     "node_modules/postcss": {
       "version": "8.5.5",

--- a/next/package.json
+++ b/next/package.json
@@ -26,7 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.15.0",
-    "heic-convert": "^2.1.0",
+    "heic2any": "^0.0.4",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.514.0",
     "moment-timezone": "^0.5.48",
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.16",
+    "@types/heic-convert": "^2.1.0",
     "@types/react": "^19.1.0",
     "dotenv-cli": "^8.0.0",
     "tailwindcss": "^4",

--- a/next/src/app/(site)/(header-static)/tools/download-time-calculator/page.js
+++ b/next/src/app/(site)/(header-static)/tools/download-time-calculator/page.js
@@ -1,0 +1,33 @@
+import ToolLayout from "@/components/ToolLayout";
+import DownloadTimeCalculator from "@/components/tools/DownloadTimeCalculator";
+import RelatedLinks from "@/components/RelatedLinks";
+
+export const metadata = {
+  title: "Download Time Calculator | Transfer.zip",
+  description: "Estimate how long a download will take based on file size and internet speed.",
+  openGraph: {
+    title: "Download Time Calculator | Transfer.zip",
+    description: "Estimate how long a download will take based on file size and internet speed.",
+    images: ["https://cdn.transfer.zip/og.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <div>
+      <ToolLayout heroTitle={<span><span className="text-primary">Calculate</span> download time</span>} heroSubtitle="See how long a file will take to download with your current connection speed.">
+        <DownloadTimeCalculator />
+      </ToolLayout>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 mb-16">
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">About this tool</h2>
+          <p className="text-lg mb-2">Enter a file size and your connection speed to get an instant estimate of how long the download will take.</p>
+          <p className="text-lg mb-2">No data is sent anywhere – the calculation happens entirely in your browser.</p>
+        </div>
+        <div className="mt-16">
+          <RelatedLinks currentSlug="download-time-calculator" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/app/(site)/(header-static)/tools/download-time-calculator/page.js
+++ b/next/src/app/(site)/(header-static)/tools/download-time-calculator/page.js
@@ -22,7 +22,7 @@ export default function Page() {
         <div className="mt-16">
           <h2 className="inline-block text-2xl mb-4 font-bold">About this tool</h2>
           <p className="text-lg mb-2">Enter a file size and your connection speed to get an instant estimate of how long the download will take.</p>
-          <p className="text-lg mb-2">No data is sent anywhere – the calculation happens entirely in your browser.</p>
+          {/* <p className="text-lg mb-2">No data is sent anywhere - the calculation happens entirely in your browser.</p> */}
         </div>
         <div className="mt-16">
           <RelatedLinks currentSlug="download-time-calculator" />

--- a/next/src/app/(site)/(header-static)/tools/heic-convert/page.js
+++ b/next/src/app/(site)/(header-static)/tools/heic-convert/page.js
@@ -1,0 +1,46 @@
+import ToolLayout from "@/components/ToolLayout";
+import HeicConvertTool from "@/components/tools/HeicConvertTool";
+import RelatedLinks from "@/components/RelatedLinks";
+import MultiStepAction from "@/components/MultiStepAction";
+import Link from 'next/link';
+
+export const metadata = {
+  title: "HEIC to JPG Converter | Transfer.zip",
+  description: "Convert HEIC photos to JPG format without uploading them anywhere.",
+  openGraph: {
+    title: "HEIC to JPG Converter | Transfer.zip",
+    description: "Convert HEIC photos to JPG format without uploading them anywhere.",
+    images: ["https://cdn.transfer.zip/og.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <div>
+      <ToolLayout heroTitle={<span><span className="text-primary">Convert HEIC</span> to JPG online</span>} heroSubtitle="Easily convert your HEIC files to JPG format with our online tool. Your photos remain completely private - even from us.">
+        <HeicConvertTool />
+      </ToolLayout>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 mb-16">
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">How does it work?</h2>
+          <p className="text-lg mb-2">Simply choose the HEIC files from your computer, and they will be converted instantly.</p>
+          <p className="text-lg mb-2">You can then choose to share individual photos for free if needed.</p>
+          <p className="text-lg mb-2"><b>Your files never leave your computer</b> - everything is processed in your browser only.</p>
+          <p className="text-lg mb-2">Want to check for yourself? <a className="text-primary hover:underline" href="https://github.com/robinkarlberg/transfer.zip-web">Check the code on GitHub &rarr;</a></p>
+        </div>
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">How do I use the tool?</h2>
+          <span className="ms-2 text-gray-500">3 steps</span>
+          <MultiStepAction steps={[
+            { step: 1, icon: "hand-index", text: "Pick your HEIC files" },
+            { step: 2, icon: "hourglass-split", text: "Click 'Convert' and wait" },
+            { step: 3, icon: "cloud-arrow-down-fill", text: <span>Download or <Link className="text-primary hover:underline" href="/quick">share files</Link></span> },
+          ]} />
+        </div>
+        <div className="mt-16">
+          <RelatedLinks currentSlug="heic-convert" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/app/(site)/(header-static)/tools/metadata-editor/page.js
+++ b/next/src/app/(site)/(header-static)/tools/metadata-editor/page.js
@@ -1,0 +1,33 @@
+import ToolLayout from "@/components/ToolLayout";
+import MetadataEditorTool from "@/components/tools/MetadataEditorTool";
+import RelatedLinks from "@/components/RelatedLinks";
+
+export const metadata = {
+  title: "File Metadata Editor | Transfer.zip",
+  description: "Edit image EXIF metadata or MP3 ID3 tags privately in your browser without uploading.",
+  openGraph: {
+    title: "File Metadata Editor | Transfer.zip",
+    description: "Edit image EXIF metadata or MP3 ID3 tags privately in your browser without uploading.",
+    images: ["https://cdn.transfer.zip/og.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <div>
+      <ToolLayout heroTitle={<span><span className="text-primary">Edit file metadata</span> online</span>} heroSubtitle="Change any EXIF tag or MP3 metadata privately in your browser.">
+        <MetadataEditorTool />
+      </ToolLayout>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 mb-16">
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">About this tool</h2>
+          <p className="text-lg mb-2">Edit any EXIF field such as camera settings or GPS coordinates, and update the title or artist of your MP3 files.</p>
+          <p className="text-lg mb-2"><b>Your files never leave your computer</b> - everything is processed in your browser.</p>
+        </div>
+        <div className="mt-16">
+          <RelatedLinks currentSlug="metadata-editor" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/app/(site)/(header-static)/tools/page.js
+++ b/next/src/app/(site)/(header-static)/tools/page.js
@@ -13,13 +13,16 @@ export const metadata = {
 
 export default function Page() {
   return (
-    <div className="mx-auto max-w-3xl px-6 py-24">
-      <h1 className="text-4xl font-bold mb-8">Free Online Tools</h1>
-      <ul className="list-disc ms-5 text-lg space-y-2">
-        {tools.map(t => (
-          <li key={t.slug}><Link href={`/tools/${t.slug}`} className="text-primary hover:underline">{t.title}</Link></li>
-        ))}
-      </ul>
+    <div className="bg-white px-6 py-32 lg:px-8">
+      <div className="mx-auto max-w-3xl text-base leading-7 text-gray-700">
+        <p className="text-base font-semibold leading-7 text-primary"><Link href="/legal">Tools</Link></p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Free Online Tools</h1>
+        <ul className="list-disc ms-5 text-lg space-y-2 mt-8">
+          {tools.map(t => (
+            <li key={t.slug}><Link href={`/tools/${t.slug}`} className="text-primary hover:underline">{t.title}</Link></li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/next/src/app/(site)/(header-static)/tools/page.js
+++ b/next/src/app/(site)/(header-static)/tools/page.js
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { tools } from '@/lib/tools';
+
+export const metadata = {
+  title: "Free Online Tools | Transfer.zip",
+  description: "Handy browser tools for zip compression, conversion and more.",
+  openGraph: {
+    title: "Free Online Tools | Transfer.zip",
+    description: "Handy browser tools for zip compression, conversion and more.",
+    images: ["https://cdn.transfer.zip/og.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-24">
+      <h1 className="text-4xl font-bold mb-8">Free Online Tools</h1>
+      <ul className="list-disc ms-5 text-lg space-y-2">
+        {tools.map(t => (
+          <li key={t.slug}><Link href={`/tools/${t.slug}`} className="text-primary hover:underline">{t.title}</Link></li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/next/src/app/(site)/(header-static)/tools/unzip-files-online/page.js
+++ b/next/src/app/(site)/(header-static)/tools/unzip-files-online/page.js
@@ -17,7 +17,7 @@ export const metadata = {
 export default function Page() {
   return (
     <div>
-      <ToolLayout heroTitle={<span><span className="text-primary">Easily</span> open your zip file online.</span>} heroSubtitle="Decompress and view even the largest zip files with this online tool. We can not read your files, as everything is handled locally in your browser.">
+      <ToolLayout large heroTitle={<span><span className="text-primary">Easily</span> open your zip file online.</span>} heroSubtitle="Decompress and view even the largest zip files with this online tool. We can not read your files, as everything is handled locally in your browser.">
         <UnzipFilesTool />
       </ToolLayout>
       <div className="mx-auto max-w-7xl px-6 lg:px-8 mb-16">

--- a/next/src/app/(site)/(header-static)/tools/unzip-files-online/page.js
+++ b/next/src/app/(site)/(header-static)/tools/unzip-files-online/page.js
@@ -1,0 +1,46 @@
+import ToolLayout from "@/components/ToolLayout";
+import UnzipFilesTool from "@/components/tools/UnzipFilesTool";
+import RelatedLinks from "@/components/RelatedLinks";
+import MultiStepAction from "@/components/MultiStepAction";
+import Link from 'next/link';
+
+export const metadata = {
+  title: "Unzip Files Online | Transfer.zip",
+  description: "Decompress and view large zip files directly in your browser.",
+  openGraph: {
+    title: "Unzip Files Online | Transfer.zip",
+    description: "Decompress and view large zip files directly in your browser.",
+    images: ["https://cdn.transfer.zip/og.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <div>
+      <ToolLayout heroTitle={<span><span className="text-primary">Easily</span> open your zip file online.</span>} heroSubtitle="Decompress and view even the largest zip files with this online tool. We can not read your files, as everything is handled locally in your browser.">
+        <UnzipFilesTool />
+      </ToolLayout>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 mb-16">
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">How does it work?</h2>
+          <p className="text-lg mb-2">Simply upload a zip file from your computer, and it will be unpacked instantly, allowing you to view its contents.</p>
+          <p className="text-lg mb-2">You can then choose to download or share individual files for free if needed.</p>
+          <p className="text-lg mb-2"><b>Your files never leave your computer</b> - everything is processed in your browser only.</p>
+          <p className="text-lg mb-2">Want to check for yourself? <a className="text-primary hover:underline" href="https://github.com/robinkarlberg/transfer.zip-web">Check the code on GitHub &rarr;</a></p>
+        </div>
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">How do I use the tool?</h2>
+          <span className="ms-2 text-gray-500">3 steps</span>
+          <MultiStepAction steps={[
+            { step: 1, icon: "hand-index", text: "Pick your zip file" },
+            { step: 2, icon: "hourglass-split", text: "Click 'Unzip' and wait" },
+            { step: 3, icon: "cloud-arrow-down-fill", text: <span>View, download or <Link className="text-primary hover:underline" href="/quick">share files</Link></span> },
+          ]} />
+        </div>
+        <div className="mt-16">
+          <RelatedLinks currentSlug="unzip-files-online" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/app/(site)/(header-static)/tools/zip-files-online/page.js
+++ b/next/src/app/(site)/(header-static)/tools/zip-files-online/page.js
@@ -1,0 +1,46 @@
+import ToolLayout from "@/components/ToolLayout";
+import ZipFilesTool from "@/components/tools/ZipFilesTool";
+import RelatedLinks from "@/components/RelatedLinks";
+import MultiStepAction from "@/components/MultiStepAction";
+import Link from 'next/link';
+
+export const metadata = {
+  title: "Zip Files Online | Transfer.zip",
+  description: "Create zip files directly in your browser without uploading them anywhere.",
+  openGraph: {
+    title: "Zip Files Online | Transfer.zip",
+    description: "Create zip files directly in your browser without uploading them anywhere.",
+    images: ["https://cdn.transfer.zip/og.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <div>
+      <ToolLayout heroTitle={<span><span className="text-primary">Easily</span> create zip files online.</span>} heroSubtitle="Effortlessly compress even the biggest files with this online file and folder zip tool. You can also choose to share the zip file for free afterwards, if you need to.">
+        <ZipFilesTool />
+      </ToolLayout>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 mb-16">
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">How does it work?</h2>
+          <p className="text-lg mb-2">Simply pick files and folders from your computer, and they will be compressed instantly into one zip file.</p>
+          <p className="text-lg mb-2">You can then choose to download or share the newly created zip file for free if needed.</p>
+          <p className="text-lg mb-2"><b>Your files never leave your computer</b> - everything is processed in your browser only.</p>
+          <p className="text-lg mb-2">Want to check for yourself? <a className="text-primary hover:underline" href="https://github.com/robinkarlberg/transfer.zip-web">Check the code on GitHub &rarr;</a></p>
+        </div>
+        <div className="mt-16">
+          <h2 className="inline-block text-2xl mb-4 font-bold">How do I use the tool?</h2>
+          <span className="ms-2 text-gray-500">3 steps</span>
+          <MultiStepAction steps={[
+            { step: 1, icon: "hand-index", text: "Pick your files or select a folder" },
+            { step: 2, icon: "hourglass-split", text: "Click 'Zip' and wait" },
+            { step: 3, icon: "cloud-arrow-down-fill", text: <span>Download or <Link className="text-primary hover:underline" href="/quick">share your zip file</Link></span> },
+          ]} />
+        </div>
+        <div className="mt-16">
+          <RelatedLinks currentSlug="zip-files-online" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/components/Footer.js
+++ b/next/src/components/Footer.js
@@ -1,8 +1,9 @@
 import Link from 'next/link';
 
-import logo from "@/img/icon.png"
+import logo from "@/img/icon.png";
 import BIcon from "./BIcon";
 import Image from 'next/image';
+import { tools } from '@/lib/tools';
 
 export default function Footer({ }) {
   return (
@@ -19,15 +20,13 @@ export default function Footer({ }) {
             <div>
               <h5 className="mb-6 text-sm font-semibold text-gray-900 uppercase --dark:text-white">Tools</h5>
               <ul className="text-gray-500 --dark:text-gray-400 font-medium">
-                <li className="mb-4">
-                  <Link href="/tools/zip-files-online" className="hover:underline ">Zip Files Online</Link>
-                </li>
-                <li className="mb-4">
-                  <Link href="/tools/unzip-files-online" className="hover:underline">Unzip Files Online</Link>
-                </li>
-                <li>
-                  <Link href="/tools/heic-convert" className="hover:underline">Convert HEIC to JPG</Link>
-                </li>
+                {tools.map(t => (
+                  <li key={t.slug} className="mb-4">
+                    <Link href={`/tools/${t.slug}`} className="hover:underline">
+                      {t.title}
+                    </Link>
+                  </li>
+                ))}
               </ul>
             </div>
             <div>

--- a/next/src/components/Footer.js
+++ b/next/src/components/Footer.js
@@ -7,7 +7,9 @@ import { tools } from '@/lib/tools';
 
 export default function Footer({ }) {
   return (
-    <footer className="bg-white --dark:bg-gray-900 z-10 relative">
+    // I do NOT know why the key= trick works I just tried it and it seems to fix the scroll bug LMAOOOOO
+    // Edit: didnt work
+    <footer className="bg-white --dark:bg-gray-900 z-10 relative" key={"fix-scroll-bug-asdf"}>
       <div className="mx-auto w-full max-w-screen-xl p-4 py-6 lg:py-8">
         <div className="md:flex md:justify-between">
           <div className="mb-6 md:mb-0">

--- a/next/src/components/RelatedLinks.js
+++ b/next/src/components/RelatedLinks.js
@@ -1,12 +1,18 @@
 import Link from 'next/link';
+import { getRelatedTools } from '@/lib/tools';
 
-export default function RelatedLinks({ links }) {
+export default function RelatedLinks({ links, currentSlug }) {
+  const finalLinks = links || getRelatedTools(currentSlug);
   return (
     <div>
       <h2 className="text-2xl font-bold mb-2">Related</h2>
-      <ul className="flex gap-4">
-        {links.map(link => <Link className="text-primary hover:underline" key={link.to} href={link.to} >{link.title} &rarr;</Link>)}
+      <ul className="flex gap-4 flex-wrap">
+        {finalLinks.map(link => (
+          <Link className="text-primary hover:underline" key={link.to} href={link.to}>
+            {link.title} &rarr;
+          </Link>
+        ))}
       </ul>
     </div>
-  )
+  );
 }

--- a/next/src/components/ToolLayout.js
+++ b/next/src/components/ToolLayout.js
@@ -1,4 +1,4 @@
-export default function ToolLayout({ heroTitle, heroSubtitle, children }) {
+export default function ToolLayout({ heroTitle, heroSubtitle, children, large }) {
   return (
     <div className="bg-white">
       <div className="relative isolate">
@@ -26,7 +26,7 @@ export default function ToolLayout({ heroTitle, heroSubtitle, children }) {
           </svg>
           <rect fill="url(#tool-pattern)" width="100%" height="100%" strokeWidth={0} />
         </svg>
-        <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:flex lg:items-center lg:gap-x-10 lg:px-8 lg:py-40">
+        <div className={`mx-auto max-w-7xl px-6 py-24 sm:py-32 ${large ? "" : "lg:flex lg:items-center lg:gap-x-10 lg:px-8 lg:py-40"}`}>
           <div className="mx-auto max-w-2xl lg:mx-0 lg:flex-auto">
             <h1 className="mt-10 max-w-lg text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
               {heroTitle}
@@ -35,7 +35,7 @@ export default function ToolLayout({ heroTitle, heroSubtitle, children }) {
               {heroSubtitle}
             </p>
           </div>
-          <div className="mt-16 sm:mt-24 lg:mt-0 lg:flex-shrink-0 lg:flex-grow">
+          <div className={`mt-16 sm:mt-24 lg:mt-0 lg:flex-shrink-0 lg:flex-grow`}>
             {children}
           </div>
         </div>

--- a/next/src/components/ToolLayout.js
+++ b/next/src/components/ToolLayout.js
@@ -1,0 +1,45 @@
+export default function ToolLayout({ heroTitle, heroSubtitle, children }) {
+  return (
+    <div className="bg-white">
+      <div className="relative isolate">
+        <svg
+          aria-hidden="true"
+          className="absolute inset-0 -z-10 h-full w-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]"
+        >
+          <defs>
+            <pattern
+              id="tool-pattern"
+              x="50%"
+              y={-1}
+              width={200}
+              height={200}
+              patternUnits="userSpaceOnUse"
+            >
+              <path d="M100 200V.5M.5 .5H200" fill="none" />
+            </pattern>
+          </defs>
+          <svg x="50%" y={-1} className="overflow-visible fill-gray-50">
+            <path
+              d="M-100.5 0h201v201h-201Z M699.5 0h201v201h-201Z M499.5 400h201v201h-201Z M-300.5 600h201v201h-201Z"
+              strokeWidth={0}
+            />
+          </svg>
+          <rect fill="url(#tool-pattern)" width="100%" height="100%" strokeWidth={0} />
+        </svg>
+        <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:flex lg:items-center lg:gap-x-10 lg:px-8 lg:py-40">
+          <div className="mx-auto max-w-2xl lg:mx-0 lg:flex-auto">
+            <h1 className="mt-10 max-w-lg text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
+              {heroTitle}
+            </h1>
+            <p className="mt-6 text-lg leading-8 text-gray-600 max-w-lg">
+              {heroSubtitle}
+            </p>
+          </div>
+          <div className="mt-16 sm:mt-24 lg:mt-0 lg:flex-shrink-0 lg:flex-grow">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/components/elements/FileBrowser.js
+++ b/next/src/components/elements/FileBrowser.js
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
-import { buildNestedStructure, createRichFileObject } from "../../utils";
 import BIcon from "../BIcon";
-import { humanFileSize } from "../../transferUtils";
+import { humanFileSize } from "@/lib/transferUtils";
+import { buildNestedStructure } from "@/lib/utils";
 
 const FileBrowserEntry = ({ richFile, isOpen, onClick }) => {
   return (

--- a/next/src/components/tools/DownloadTimeCalculator.js
+++ b/next/src/components/tools/DownloadTimeCalculator.js
@@ -1,45 +1,69 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "../ui/select";
+import { Input } from "../ui/input";
 
 function format(seconds) {
+  if (!seconds || !isFinite(seconds)) return "—";
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   const s = Math.round(seconds % 60);
-  return [
-    h ? h + "h" : null,
-    m ? m + "m" : null,
-    (!h && !m) || s ? s + "s" : null,
-  ].filter(Boolean).join(" ");
+  return [h ? h + "h" : null, m ? m + "m" : null, s ? s + "s" : "Instantly ;)"]
+    .filter(Boolean)
+    .join(" ");
 }
 
-export default function DownloadTimeCalculator() {
-  const [size, setSize] = useState(100);
+export default function DownloadCalculator() {
+  const [size, setSize] = useState("");
   const [unit, setUnit] = useState("MB");
-  const [speed, setSpeed] = useState(50);
+  const [speed, setSpeed] = useState("");
+  const [speedUnit, setSpeedUnit] = useState("Mbps");
 
-  const seconds = useMemo(() => {
-    const bytes = parseFloat(size || 0) * (unit === "GB" ? 1e9 : 1e6);
-    const bits = bytes * 8;
-    const bps = parseFloat(speed || 0) * 1e6;
-    if (!bps) return 0;
-    return bits / bps;
-  }, [size, unit, speed]);
+  // derived values
+  const bytes = (parseFloat(size) || 0) * (unit === "GB" ? 1e9 : 1e6);
+  const bps = (parseFloat(speed) || 0) * (speedUnit === "MBps" ? 1e6 * 8 : 1e6);
+  const seconds = bps ? (bytes * 8) / bps : 0;
 
   return (
-    <div className="border rounded-xl p-6 shadow-sm w-full max-w-md">
-      <div className="flex gap-2 mb-4">
-        <input type="number" className="border rounded p-2 w-full" value={size} onChange={e => setSize(e.target.value)} />
-        <select className="border rounded p-2" value={unit} onChange={e => setUnit(e.target.value)}>
-          <option>MB</option>
-          <option>GB</option>
-        </select>
+    <div className="border rounded-2xl p-6 shadow-sm w-full max-w-md bg-white grid gap-4">
+      {/* Size */}
+      <div className="flex gap-2">
+        <Input
+          type="number"
+          placeholder="Size"
+          value={size}
+          onChange={(e) => setSize(e.target.value)}
+        />
+        <Select value={unit} onValueChange={setUnit}>
+          <SelectTrigger className="w-24">{unit}</SelectTrigger>
+          <SelectContent>
+            <SelectItem value="MB">MB</SelectItem>
+            <SelectItem value="GB">GB</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
-      <div className="flex gap-2 mb-4">
-        <input type="number" className="border rounded p-2 w-full" value={speed} onChange={e => setSpeed(e.target.value)} />
-        <span className="self-center">Mbps</span>
+
+      {/* Speed */}
+      <div className="flex gap-2">
+        <Input
+          type="number"
+          placeholder="Speed"
+          value={speed}
+          onChange={(e) => setSpeed(e.target.value)}
+        />
+        <Select value={speedUnit} onValueChange={setSpeedUnit}>
+          <SelectTrigger className="w-28">{speedUnit}</SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Mbps">Mbps</SelectItem>
+            <SelectItem value="MBps">MBps</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
-      <p className="font-semibold text-center">Estimated time: {format(seconds)}</p>
+
+      <p className="text-center text-sm text-gray-500">
+        {seconds ? format(seconds) : "—"}
+      </p>
     </div>
   );
 }

--- a/next/src/components/tools/DownloadTimeCalculator.js
+++ b/next/src/components/tools/DownloadTimeCalculator.js
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+function format(seconds) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.round(seconds % 60);
+  return [
+    h ? h + "h" : null,
+    m ? m + "m" : null,
+    (!h && !m) || s ? s + "s" : null,
+  ].filter(Boolean).join(" ");
+}
+
+export default function DownloadTimeCalculator() {
+  const [size, setSize] = useState(100);
+  const [unit, setUnit] = useState("MB");
+  const [speed, setSpeed] = useState(50);
+
+  const seconds = useMemo(() => {
+    const bytes = parseFloat(size || 0) * (unit === "GB" ? 1e9 : 1e6);
+    const bits = bytes * 8;
+    const bps = parseFloat(speed || 0) * 1e6;
+    if (!bps) return 0;
+    return bits / bps;
+  }, [size, unit, speed]);
+
+  return (
+    <div className="border rounded-xl p-6 shadow-sm w-full max-w-md">
+      <div className="flex gap-2 mb-4">
+        <input type="number" className="border rounded p-2 w-full" value={size} onChange={e => setSize(e.target.value)} />
+        <select className="border rounded p-2" value={unit} onChange={e => setUnit(e.target.value)}>
+          <option>MB</option>
+          <option>GB</option>
+        </select>
+      </div>
+      <div className="flex gap-2 mb-4">
+        <input type="number" className="border rounded p-2 w-full" value={speed} onChange={e => setSpeed(e.target.value)} />
+        <span className="self-center">Mbps</span>
+      </div>
+      <p className="font-semibold text-center">Estimated time: {format(seconds)}</p>
+    </div>
+  );
+}

--- a/next/src/components/tools/HeicConvertTool.js
+++ b/next/src/components/tools/HeicConvertTool.js
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import FileUpload from "../elements/FileUpload";
+import Progress from "../elements/Progress";
+import { downloadBlob } from "@/lib/utils";
+import streamSaver from "@/lib/client/StreamSaver";
+import * as zip from "@zip.js/zip.js";
+
+export default function HeicConvertTool() {
+  const [now, setNow] = useState(0);
+  const [max, setMax] = useState(0);
+
+  const doConvert = async (file) => {
+    const buffer = await file.arrayBuffer();
+    const { default: convert } = await import("heic-convert/browser");
+    const outputBuffer = await convert({ buffer, format: "JPEG", quality: 0.9 });
+    return outputBuffer;
+  };
+
+  const handleFiles = async (_files) => {
+    if (_files.length === 0) return;
+    const files = Array.from(_files).filter((f) => /\.heic$/i.test(f.name));
+    if (files.length === 0) return;
+    setMax(files.length);
+
+    if (files.length === 1) {
+      const newFileName = files[0].name.replace(/\.heic$/i, ".jpg");
+      downloadBlob(new Blob([await doConvert(files[0])]), newFileName);
+      setNow(1);
+    } else {
+      const zipStream = new zip.ZipWriterStream({ zip64: true, bufferedWrite: true });
+      const fileStream = streamSaver.createWriteStream("Converted JPGs.zip");
+      zipStream.readable.pipeTo(fileStream);
+      for (let index = 0; index < files.length; index++) {
+        const file = files[index];
+        const outputBuffer = await doConvert(file);
+        let writer = zipStream.writable(file.name.replace(/\.heic$/i, ".jpg")).getWriter();
+        writer.write(outputBuffer);
+        writer.close();
+        setNow(index + 1);
+      }
+      await zipStream.close();
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-sm">
+      <FileUpload onFiles={handleFiles} buttonText="Convert" showProgress={max !== 0} accept=".heic" progressElement={<Progress now={now} max={max} />} />
+    </div>
+  );
+}

--- a/next/src/components/tools/HeicConvertTool.js
+++ b/next/src/components/tools/HeicConvertTool.js
@@ -7,14 +7,16 @@ import { downloadBlob } from "@/lib/utils";
 import streamSaver from "@/lib/client/StreamSaver";
 import * as zip from "@zip.js/zip.js";
 
+const heic2any = typeof window !== "undefined" ? require("heic2any") : null
+
 export default function HeicConvertTool() {
   const [now, setNow] = useState(0);
   const [max, setMax] = useState(0);
 
   const doConvert = async (file) => {
-    const buffer = await file.arrayBuffer();
-    const { default: convert } = await import("heic-convert/browser");
-    const outputBuffer = await convert({ buffer, format: "JPEG", quality: 0.9 });
+    console.log(heic2any)
+    const outputBuffer = await heic2any({ blob: file, format: "JPEG", quality: 0.9 });
+    console.log(outputBuffer)
     return outputBuffer;
   };
 

--- a/next/src/components/tools/MetadataEditorTool.js
+++ b/next/src/components/tools/MetadataEditorTool.js
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from 'react';
+import FileUpload from "../elements/FileUpload";
+
+export default function MetadataEditorTool() {
+  const [file, setFile] = useState(null);
+  const [info, setInfo] = useState(null);
+  const [fields, setFields] = useState([]);
+  const [title, setTitle] = useState('');
+  const [artist, setArtist] = useState('');
+
+  const handleFiles = async (files) => {
+    if (!files.length) return;
+    const f = files[0];
+    setFile(f);
+    if (f.type.startsWith('image/')) {
+      await new Promise(res => {
+        const s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/piexifjs';
+        s.onload = res;
+        document.head.appendChild(s);
+      });
+      const reader = new FileReader();
+      reader.onload = () => {
+        const exif = window.piexif.load(reader.result);
+        const flds = [];
+        ['0th','Exif','GPS','1st'].forEach(sec => {
+          const secData = exif[sec];
+          if (!secData) return;
+          for (const tag in secData) {
+            const info = window.piexif.TAGS[sec][tag];
+            const name = info ? info.name : tag;
+            let val = secData[tag];
+            if (typeof val === 'object') val = JSON.stringify(val);
+            flds.push({ section: sec, tag, name, value: String(val) });
+          }
+        });
+        setFields(flds);
+        setInfo({type:'image', dataURL: reader.result, exif});
+      };
+      reader.readAsDataURL(f);
+    } else if (f.type === 'audio/mpeg') {
+      await new Promise(res => {
+        const s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/jsmediatags@3/dist/jsmediatags.min.js';
+        s.onload = res;
+        document.head.appendChild(s);
+      });
+      window.jsmediatags.read(f, {
+        onSuccess: ({tags}) => {
+          setTitle(tags.title || '');
+          setArtist(tags.artist || '');
+          setInfo({type:'audio'});
+        },
+        onError: console.error
+      });
+      setFields([]);
+    }
+  };
+
+  const saveImage = () => {
+    const exif = JSON.parse(JSON.stringify(info.exif));
+    fields.forEach(f => {
+      let val = f.value;
+      try {
+        val = JSON.parse(val);
+      } catch {
+        const num = Number(val);
+        if (!Number.isNaN(num)) val = num;
+      }
+      if (!exif[f.section]) exif[f.section] = {};
+      exif[f.section][f.tag] = val;
+    });
+    const exifStr = window.piexif.dump(exif);
+    const newDataURL = window.piexif.insert(exifStr, info.dataURL);
+    const a = document.createElement('a');
+    a.href = newDataURL;
+    a.download = file.name.replace(/\.jpe?g$/i, '_meta.jpg');
+    a.click();
+  };
+
+  const saveAudio = async () => {
+    await new Promise(res => { const s=document.createElement('script'); s.src='https://cdn.jsdelivr.net/npm/browser-id3-writer'; s.onload=res; document.head.appendChild(s); });
+    const buffer = await file.arrayBuffer();
+    const writer = new window.ID3Writer(buffer);
+    writer.setFrame('TIT2', title).setFrame('TPE1', [artist]);
+    writer.addTag();
+    const blob = writer.getBlob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = file.name.replace(/\.mp3$/i, '_meta.mp3');
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div>
+      <div className="mx-auto max-w-sm">
+        <FileUpload onFiles={handleFiles} buttonText="Select file" singleFile />
+      </div>
+      {info?.type==='image' && (
+        <div className="mt-4 space-y-2">
+          {fields.map((f, idx) => (
+            <label key={idx} className="block">
+              {f.section} {f.name}
+              <input
+                className="border rounded p-2 w-full"
+                value={f.value}
+                onChange={e => {
+                  const newFields = [...fields];
+                  newFields[idx].value = e.target.value;
+                  setFields(newFields);
+                }}
+              />
+            </label>
+          ))}
+          <button onClick={saveImage} className="mt-2 border rounded p-2 bg-primary text-white">Save Image</button>
+        </div>
+      )}
+      {info?.type==='audio' && (
+        <div className="mt-4 space-y-2">
+          <label className="block">Title <input className="border p-2 rounded w-full" value={title} onChange={e=>setTitle(e.target.value)} /></label>
+          <label className="block">Artist <input className="border p-2 rounded w-full" value={artist} onChange={e=>setArtist(e.target.value)} /></label>
+          <button onClick={saveAudio} className="mt-2 border rounded p-2 bg-primary text-white">Save MP3</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/next/src/components/tools/UnzipFilesTool.js
+++ b/next/src/components/tools/UnzipFilesTool.js
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import FileUpload from "../elements/FileUpload";
+import FileBrowser from "../elements/FileBrowser";
+import EmptySpace from "../elements/EmptySpace";
+import streamSaver from "@/lib/client/StreamSaver";
+import * as zip from "@zip.js/zip.js";
+
+let zipFileReader;
+let zipReader;
+
+const unzip = async (zipFile) => {
+  const _files = [];
+  zipFileReader = new zip.BlobReader(zipFile);
+  zipReader = new zip.ZipReader(zipFileReader);
+  const entries = await zipReader.getEntries();
+  for (const entry of entries) {
+    const split = entry.filename.split("/");
+    if (!entry.directory) _files.push({ info: { name: split[split.length - 1], size: entry.uncompressedSize, relativePath: entry.filename, type: "application/octet-stream" }, entry });
+  }
+  return _files;
+};
+
+export default function UnzipFilesTool() {
+  const [richFiles, setRichFiles] = useState(null);
+  const [zipFile, setZipFile] = useState(null);
+
+  const handleFiles = async (files) => {
+    if (!files.length) return;
+    const file = files[0];
+    setZipFile(file);
+    setRichFiles(await unzip(file));
+  };
+
+  const handleAction = async (action, richFile) => {
+    if (action === "click") {
+      const fileStream = streamSaver.createWriteStream(richFile.info.name);
+      await richFile.entry.getData(fileStream);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mx-auto max-w-sm">
+        <FileUpload onFiles={handleFiles} buttonText="Unzip" singleFile accept=".zip" />
+      </div>
+      <div className="mt-4">
+        {richFiles ? (
+          <div>
+            <h3 className="text-2xl font-bold mb-4">{zipFile?.name}</h3>
+            <FileBrowser richFiles={richFiles} onAction={handleAction} />
+          </div>
+        ) : (
+          <EmptySpace title={`Select a ZIP file to get started`} subtitle={`Your files will be displayed here, allowing you to browse the archive.`} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/next/src/components/tools/ZipFilesTool.js
+++ b/next/src/components/tools/ZipFilesTool.js
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import FileUpload from "../elements/FileUpload";
+import Progress from "../elements/Progress";
+import streamSaver from "@/lib/client/StreamSaver";
+import * as zip from "@zip.js/zip.js";
+import { readFileTillEnd } from "@/lib/utils";
+
+export default function ZipFilesTool() {
+  const [files, setFiles] = useState(null);
+  const maxBytes = useMemo(() => files && files.reduce((sum, f) => sum + f.size, 0), [files]);
+  const [progressBytes, setProgressBytes] = useState(0);
+
+  const doZip = async () => {
+    let currentBytes = 0;
+    const zipStream = new zip.ZipWriterStream({ zip64: true, bufferedWrite: true });
+    const fileStream = streamSaver.createWriteStream("archive.zip");
+    const fileWriter = fileStream.getWriter();
+    const trackingStream = new WritableStream({
+      write(chunk) {
+        currentBytes += chunk.byteLength;
+        setProgressBytes(currentBytes);
+        return fileWriter.write(chunk);
+      },
+      close() { return fileWriter.close(); },
+      abort(r) { return fileWriter.abort(r); }
+    });
+
+    zipStream.readable.pipeTo(trackingStream);
+    for (let file of files) {
+      let writer = zipStream.writable(file.webkitRelativePath || file.name).getWriter();
+      await readFileTillEnd(file, data => writer.write(data));
+      writer.close();
+    }
+    await zipStream.close();
+  };
+
+  const handleFiles = (fs) => { if (fs.length) setFiles(fs); };
+
+  useEffect(() => { if (files) doZip(); }, [files]);
+
+  return (
+    <div className="mx-auto max-w-sm">
+      <FileUpload onFiles={handleFiles} buttonText="Zip" showProgress={!!maxBytes} progressElement={<Progress max={maxBytes} now={progressBytes} />} />
+    </div>
+  );
+}

--- a/next/src/components/tools/ZipFilesTool.js
+++ b/next/src/components/tools/ZipFilesTool.js
@@ -34,6 +34,7 @@ export default function ZipFilesTool() {
       writer.close();
     }
     await zipStream.close();
+    setProgressBytes(maxBytes)
   };
 
   const handleFiles = (fs) => { if (fs.length) setFiles(fs); };

--- a/next/src/lib/tools.js
+++ b/next/src/lib/tools.js
@@ -1,0 +1,12 @@
+export const tools = [
+  { slug: 'zip-files-online', title: 'Zip Files Online', description: 'Create zip files directly in your browser.' },
+  { slug: 'unzip-files-online', title: 'Unzip Files Online', description: 'Decompress zip archives without uploading.' },
+  { slug: 'heic-convert', title: 'Convert HEIC to JPG', description: 'Turn HEIC photos into JPG format instantly.' },
+  { slug: 'download-time-calculator', title: 'Download Time Calculator', description: 'Estimate how long a download will take.' },
+  { slug: 'metadata-editor', title: 'File Metadata Editor', description: 'Edit any EXIF tag or audio ID3 metadata.' },
+];
+
+export function getRelatedTools(currentSlug, max = 3) {
+  const others = tools.filter(t => t.slug !== currentSlug);
+  return others.slice(0, max).map(t => ({ to: `/tools/${t.slug}`, title: t.title }));
+}


### PR DESCRIPTION
## Summary
- migrate frontend tools to Next.js
- add tool metadata in `tools.js`
- automate related links with updated `RelatedLinks`
- implement a metadata editor tool for EXIF and ID3 tags
- generate footer and index from tool list
- **Allow editing any EXIF tag in the metadata editor**

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686860dac13c8322820af079f2609300