### PR TITLE
Fix missing checks in API routes

### DIFF
--- a/next/src/app/api/transfer/[transferId]/delete/route.js
+++ b/next/src/app/api/transfer/[transferId]/delete/route.js
@@ -13,8 +13,12 @@ export async function POST(req, { params }) {
 
   const transfer = await Transfer.findOne({ author: auth.user._id, _id: transferId })
 
+  if (!transfer) {
+    return NextResponse.json(resp("transfer not found"), { status: 404 })
+  }
+
   await transfer.deleteOne()
-  workerTransferDelete(transfer.nodeUrl, transfer._id.toString())
+  await workerTransferDelete(transfer.nodeUrl, transfer._id.toString())
 
   return NextResponse.json(resp({}))
 }

--- a/next/src/app/api/transfer/[transferId]/route.js
+++ b/next/src/app/api/transfer/[transferId]/route.js
@@ -13,6 +13,10 @@ export async function PUT(req, { params }) {
 
   const transfer = await Transfer.findOne({ author: user._id, _id: { $eq: transferId } })
 
+  if (!transfer) {
+    return NextResponse.json(resp("transfer not found"), { status: 404 })
+  }
+
   if (name || name === "") transfer.name = name
   if (description || description === "") transfer.description = description
 

--- a/next/src/app/api/transferrequest/[transferRequestId]/activate/route.js
+++ b/next/src/app/api/transferrequest/[transferRequestId]/activate/route.js
@@ -7,6 +7,9 @@ export async function POST(req, { params }) {
   const { user } = await useServerAuth()
   const { transferRequestId } = await params
   const transferRequest = await TransferRequest.findOne({ author: user._id, _id: { $eq: transferRequestId } })
+  if (!transferRequest) {
+    return NextResponse.json(resp("transfer request not found"), { status: 404 })
+  }
   await TransferRequest.updateOne(
     { _id: transferRequest._id },
     { $set: { active: true } }

--- a/next/src/app/api/transferrequest/[transferRequestId]/deactivate/route.js
+++ b/next/src/app/api/transferrequest/[transferRequestId]/deactivate/route.js
@@ -7,6 +7,9 @@ export async function POST(req, { params }) {
   const { user } = await useServerAuth()
   const { transferRequestId } = await params
   const transferRequest = await TransferRequest.findOne({ author: user._id, _id: { $eq: transferRequestId } })
+  if (!transferRequest) {
+    return NextResponse.json(resp("transfer request not found"), { status: 404 })
+  }
   await TransferRequest.updateOne(
     { _id: transferRequest._id },
     { $set: { active: false } }

--- a/next/src/app/api/upload/[secretCode]/complete/route.js
+++ b/next/src/app/api/upload/[secretCode]/complete/route.js
@@ -9,7 +9,9 @@ export async function POST(req, { params }) {
   const { secretCode } = await params
 
   const transfer = await Transfer.findOne({ secretCode: { $eq: secretCode } })
-  // TODO: if no transfer
+  if (!transfer) {
+    return NextResponse.json(resp("transfer not found"), { status: 404 })
+  }
 
   // TODO: Maybe add auth or something to this
 


### PR DESCRIPTION
## Summary
- check transfer exists in upload complete route
- validate transfer exists before update/delete
- validate transfer request exists before activate/deactivate

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68692f4ed0508322b3dbdc722e296643