### PR TITLE
Fix db connect usage

### DIFF
--- a/next/src/app/api/auth/google/route.js
+++ b/next/src/app/api/auth/google/route.js
@@ -1,10 +1,8 @@
-import dbConnect from "@/lib/server/mongoose/db";
 import { NextResponse } from "next/server";
 
 export const runtime = "nodejs";
 
 export async function GET() {
-  await dbConnect()
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_OAUTH_CLIENT_ID,
     redirect_uri:

--- a/next/src/app/api/auth/logout/route.js
+++ b/next/src/app/api/auth/logout/route.js
@@ -1,11 +1,9 @@
 import { NextResponse } from 'next/server';
 import { useServerAuth } from '@/lib/server/wrappers/auth';
-import dbConnect from '@/lib/server/mongoose/db';
 import Session from '@/lib/server/mongoose/models/Session';
 
 export const POST = async () => {
   const auth = await useServerAuth()
-  await dbConnect()
   await Session.deleteOne({ token: auth.token });
 
   const res = NextResponse.json({ success: true });

--- a/next/src/app/api/download/[secretCode]/downloaded/route.js
+++ b/next/src/app/api/download/[secretCode]/downloaded/route.js
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import dbConnect from '@/lib/server/mongoose/db';
 import Transfer from '@/lib/server/mongoose/models/Transfer';
 import { resp } from '@/lib/server/serverUtils';
 import { sendTransferDownloaded } from '@/lib/server/mail/mail';
@@ -9,7 +8,6 @@ const DOWNLOAD_EMAIL_COOLDOWN_MS = 1000 * 60 * 30;
 
 export async function POST(req, { params }) {
   const { secretCode } = await params;
-  await dbConnect();
 
   let auth
   try {

--- a/next/src/app/api/stripe/webhook/route.js
+++ b/next/src/app/api/stripe/webhook/route.js
@@ -3,6 +3,7 @@ import { resp } from "@/lib/server/serverUtils";
 import { NextResponse } from "next/server";
 import { buffer } from "node:stream/consumers";
 import Stripe from "stripe";
+import dbConnect from "@/lib/server/mongoose/db";
 // export const config = {
 //   api: {
 //     bodyParser: false
@@ -26,6 +27,8 @@ export async function POST(req) {
     console.error("Error verifying webhook signature:", err);
     return NextResponse.json(resp(`Webhook Error: ${err.message}`))
   }
+
+  await dbConnect();
 
   console.log("Received Stripe webhook event:", event.type);
 


### PR DESCRIPTION
## Summary
- clean up redundant DB connects
- connect to DB in Stripe webhook endpoint

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fddad69e083229e3b86154f488511