### PR TITLE
feat: hero file drag-and-drop

### DIFF
--- a/next/src/app/(site)/(header-scroll)/LandingQuickShare.js
+++ b/next/src/app/(site)/(header-scroll)/LandingQuickShare.js
@@ -1,8 +1,10 @@
 "use client"
 
 import BIcon from "@/components/BIcon"
+import FileDropOverlay from "@/components/elements/FileDropOverlay"
 import FileUpload from "@/components/elements/FileUpload"
 import { FileContext } from "@/context/FileProvider"
+import { useFileDropZone } from "@/hooks/client/useFileDropZone"
 import { useRouter } from "next/navigation"
 import { useContext } from "react"
 
@@ -20,11 +22,14 @@ export default function () {
     router.push("/quick/progress#R", { scroll: false })
   }
 
+  const { isDragging } = useFileDropZone(handleFiles)
+
   return (
     <div>
       <FileUpload onFiles={handleFiles} onReceiveClicked={handleReceiveClicked} />
       <p className="text-center mt-2 text-xs text-gray-400"><BIcon name={"lock-fill"}/> End-to-end encrypted, files not stored.</p>
       <p className="text-center text-xs text-gray-400">Want to store your files? Sign up.</p>
+      <FileDropOverlay show={isDragging} />
     </div>
   )
 }

--- a/next/src/app/(site)/(header-static)/quick/QuickShareNew.js
+++ b/next/src/app/(site)/(header-static)/quick/QuickShareNew.js
@@ -1,9 +1,11 @@
 "use client"
 
 import BIcon from "@/components/BIcon"
+import FileDropOverlay from "@/components/elements/FileDropOverlay"
 import FileUpload from "@/components/elements/FileUpload"
 import QuestionCircle from "@/components/elements/QuestionCircle"
 import { FileContext } from "@/context/FileProvider"
+import { useFileDropZone } from "@/hooks/client/useFileDropZone"
 import { useQuickShare } from "@/hooks/client/useQuickShare"
 import { getComputedNewLocation } from "@/lib/client/hash"
 import { useRouter } from "next/navigation"
@@ -37,6 +39,8 @@ export default function ({ stars }) {
     }
   }, [transferDirection])
 
+  const { isDragging } = useFileDropZone(handleFiles)
+
   return (
     <div className="w-full max-w-96 text-center">
       <div className={hasBeenSentLink ? "mb-2" : "mb-28"}>
@@ -57,6 +61,7 @@ export default function ({ stars }) {
       <p className="text-gray-500 text-xs mt-2">
         We do not use cookies. Your files are protected with end-to-end encryption, meaning they remain unreadable by anyone but you.<br /><a href="https://github.com/robinkarlberg/transfer.zip-web" className="text-primary hover:underline">GitHub {stars && <span>({stars} <BIcon name={"star"} />)</span>} </a>
       </p>
+      <FileDropOverlay show={isDragging} />
     </div>
   )
 }

--- a/next/src/components/elements/FileDropOverlay.js
+++ b/next/src/components/elements/FileDropOverlay.js
@@ -1,0 +1,28 @@
+"use client"
+
+import BIcon from "@/components/BIcon"
+import { useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+export default function FileDropOverlay({ show }) {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted || !show) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-[2147483647] bg-black/60 backdrop-blur-sm flex flex-col items-center justify-center pointer-events-none">
+      <div className="rounded-3xl border-2 border-dashed border-white/60 px-16 py-12 flex flex-col items-center">
+        <div className="text-primary rounded-full bg-white w-20 h-20 flex">
+          <BIcon name={"cloud-arrow-up-fill"} center className={"flex-grow text-5xl"} />
+        </div>
+        <p className="text-white text-3xl font-bold mt-6">Drop to send</p>
+        <p className="text-white/70 text-sm mt-2">Release anywhere on the page</p>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/next/src/hooks/client/useFileDropZone.js
+++ b/next/src/hooks/client/useFileDropZone.js
@@ -1,0 +1,70 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+export function useFileDropZone(onDropFiles) {
+  const [isDragging, setIsDragging] = useState(false)
+  const dragCounter = useRef(0)
+  const onDropFilesRef = useRef(onDropFiles)
+
+  useEffect(() => {
+    onDropFilesRef.current = onDropFiles
+  }, [onDropFiles])
+
+  useEffect(() => {
+    const hasFiles = (e) => {
+      if (!e.dataTransfer) return false
+      const types = e.dataTransfer.types
+      if (!types) return false
+      for (let i = 0; i < types.length; i++) {
+        if (types[i] === "Files") return true
+      }
+      return false
+    }
+
+    const onDragEnter = (e) => {
+      e.preventDefault()
+      if (!hasFiles(e)) return
+      dragCounter.current++
+      setIsDragging(true)
+    }
+    const onDragOver = (e) => {
+      e.preventDefault()
+      if (hasFiles(e) && e.dataTransfer) {
+        e.dataTransfer.dropEffect = "copy"
+      }
+    }
+    const onDragLeave = (e) => {
+      e.preventDefault()
+      if (!hasFiles(e)) return
+      dragCounter.current--
+      if (dragCounter.current <= 0) {
+        dragCounter.current = 0
+        setIsDragging(false)
+      }
+    }
+    const onDrop = (e) => {
+      e.preventDefault()
+      dragCounter.current = 0
+      setIsDragging(false)
+      const dropped = e.dataTransfer ? Array.from(e.dataTransfer.files || []) : []
+      if (dropped.length > 0 && onDropFilesRef.current) {
+        onDropFilesRef.current(dropped)
+      }
+    }
+
+    document.addEventListener("dragenter", onDragEnter)
+    document.addEventListener("dragover", onDragOver)
+    document.addEventListener("dragleave", onDragLeave)
+    document.addEventListener("drop", onDrop)
+
+    return () => {
+      document.removeEventListener("dragenter", onDragEnter)
+      document.removeEventListener("dragover", onDragOver)
+      document.removeEventListener("dragleave", onDragLeave)
+      document.removeEventListener("drop", onDrop)
+    }
+  }, [])
+
+  return { isDragging }
+}


### PR DESCRIPTION
## Summary
- Entire hero section is now a file drop target on `/` and `/quick` — drag a file anywhere on the page and release to start a transfer.
- While dragging files over the window, a full-screen dimmed overlay with "Drop to send" appears.